### PR TITLE
Fix typo in declaration of openai dependency

### DIFF
--- a/web_to_markdown/environment.yml
+++ b/web_to_markdown/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - beautifulsoup4==4.12.2
     - requests==2.31.0
-    - openai=1.57.4
+    - openai==1.57.4
     - python-dotenv==1.0.0
     - markdown==3.5.1
     - "flask[async]==3.0.0"

--- a/web_to_markdown/environment.yml
+++ b/web_to_markdown/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - beautifulsoup4==4.12.2
     - requests==2.31.0
-    - openai-1.57.4
+    - openai=1.57.4
     - python-dotenv==1.0.0
     - markdown==3.5.1
     - "flask[async]==3.0.0"


### PR DESCRIPTION
I think there is a little typo in the declaration of the openai dependency in environment.yml. The "-" should be a "=". 

I tried with "=" and the conda command to generate the environment succeeds. 

It also seems that previous versions of environment.yml used "=" (as do the other dependencies).
